### PR TITLE
submodule data のdevelopmentブランチの削除

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Pull submodule latest commit
         run: |
           git submodule update -i
-          cd data/ && git checkout development
+          cd data/ && git checkout master
 
       - name: Setup Node
         uses: actions/setup-node@v1


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- https://github.com/covid19-oita/data/issues/31


## ⛏ 変更内容 / Details of Changes
development環境をビルドする際、dataをdevelopmentブランチとしていたのをmasterブランチに変更する
