### PR TITLE
data取得先のURLが変更された

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,7 +7,7 @@ const environment = process.env.NODE_ENV || 'development'
 const config: Configuration = {
   mode: 'spa',
   env: {
-    apiUrl: 'https://data-covid19-oita.netlify.com/json/data.json'
+    apiUrl: 'https://data-covid19-oita.netlify.app/json/data.json'
   },
   /*
    ** Headers of the page


### PR DESCRIPTION

https://data-covid19-oita.netlify.com/json/data.json
が301を返すようになったため修正